### PR TITLE
Fix msm8992 building

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -8,7 +8,7 @@ ifneq ($(BOARD_IS_AUTOMOTIVE),true)
   else
    ifneq ($(filter msm8x27 msm8226 msm8974 msm8960,$(TARGET_BOARD_PLATFORM)),)
      include $(call all-named-subdir-makefiles,msm8960)
-   else ifneq ($(filter msm8994,$(TARGET_BOARD_PLATFORM)),)
+   else ifneq ($(filter msm8992 msm8994,$(TARGET_BOARD_PLATFORM)),)
      include $(call all-named-subdir-makefiles,msm8992)
    else ifneq ($(wildcard $(LOCAL_PATH)/$(TARGET_BOARD_PLATFORM)),)
      include $(call all-named-subdir-makefiles,$(TARGET_BOARD_PLATFORM))


### PR DESCRIPTION
When I add the bt-vendor in dependencies in msm8992, ckati shows not found this module.